### PR TITLE
Strip input text of leading/trailing spaces.

### DIFF
--- a/lib/avatarly.rb
+++ b/lib/avatarly.rb
@@ -14,7 +14,7 @@ class Avatarly
 
   class << self
     def generate_avatar(text, opts={})
-      generate_image(initials(text.to_s).upcase, parse_options(opts)).to_blob
+      generate_image(initials(text.to_s.strip).upcase, parse_options(opts)).to_blob
     end
 
     def root

--- a/spec/avatarly_spec.rb
+++ b/spec/avatarly_spec.rb
@@ -34,6 +34,12 @@ describe Avatarly do
                                                  background_color: "#000000")
         assert_image_equality(result, reference_image(:H_black_white_32))
       end
+
+      it 'does not break if input has leading or trailing space' do
+        result = described_class.generate_avatar(" HelloWorld ",
+                                                 background_color: "#000000")
+        assert_image_equality(result, reference_image(:H_black_white_32))
+      end
     end
   end
 end


### PR DESCRIPTION
Currently if input text has any leading/trailing spaces it breaks with "undefined method `[]' for nil:NilClass" error.