### PR TITLE
Fix deletion of spaces in provided text

### DIFF
--- a/lib/avatarly.rb
+++ b/lib/avatarly.rb
@@ -15,7 +15,7 @@ class Avatarly
 
   class << self
     def generate_avatar(text, opts={})
-      generate_image(initials(text.to_s.gsub(/\W/,'')).upcase, parse_options(opts)).to_blob
+      generate_image(initials(text.to_s.strip.gsub(/[^\w ]/,'')).upcase, parse_options(opts)).to_blob
     end
 
     def root

--- a/spec/avatarly_spec.rb
+++ b/spec/avatarly_spec.rb
@@ -60,6 +60,11 @@ describe Avatarly do
                                                  background_color: "#000000")
         assert_image_equality(result, :H_black_white_32)
       end
+
+      it 'strips leading/trailing whitespace without striping other whitespaces' do
+        expect(described_class).to receive(:initials).with('Hello World').and_return 'HW'
+        described_class.generate_avatar(' Hello World! ')
+      end
     end
   end
 end


### PR DESCRIPTION
Previously when " My Name " was given as input text, text was “cleaned up”
to "MyName" instead of "My Name".

This patch strips leading & trailing spaces and then deletes non-word
characters while preserving remaining spaces.