### PR TITLE
UnicodeUtils language code support for upcase

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,8 @@ source "http://rubygems.org"
 
 gemspec
 
+gem 'unicode_utils'
+
 group :development, :test do
   gem 'rspec'
   gem 'fastimage'

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ the only required parameter is <tt>text</tt>. Other options that you can pass ar
 * <tt>font</tt>  (path to font - e.g. "#{Rails.root}/your_font.ttf")
 * <tt>font_size</tt> (default: size / 2)
 * <tt>format</tt> (default: png)
+* <tt>lang</tt> (language code if unicode aware upcase required - e.g: :tr, default: nil)
 
 As a result you will get an image blob - rest is up to you, do whatever you want with it.
 

--- a/avatarly.gemspec
+++ b/avatarly.gemspec
@@ -1,6 +1,7 @@
 Gem::Specification.new do |s|
   s.add_runtime_dependency('rmagick')
   s.add_runtime_dependency('rfc822')
+  s.add_runtime_dependency('unicode_utils')
 
   s.name        = "avatarly"
   s.version     = "1.2.1"

--- a/lib/avatarly.rb
+++ b/lib/avatarly.rb
@@ -1,6 +1,7 @@
 require 'rvg/rvg'
 require 'rfc822'
 require 'pathname'
+require 'unicode_utils'
 
 class Avatarly
   BACKGROUND_COLORS = [
@@ -15,7 +16,12 @@ class Avatarly
 
   class << self
     def generate_avatar(text, opts={})
-      generate_image(initials(text.to_s.strip.gsub(/[^\w ]/,'')).upcase, parse_options(opts)).to_blob
+      if opts[:lang]
+        text = UnicodeUtils.upcase(initials(text.to_s.strip.gsub(/[^[[:word:]] ]/,'')), opts[:lang])
+      else
+        text = initials(text.to_s.strip.gsub(/[^\w ]/,'')).upcase
+      end
+      generate_image(text, parse_options(opts)).to_blob
     end
 
     def root


### PR DESCRIPTION
We need to use UnicodeUtils' upcase for some languages.

For example, upcase of "i" in Turkish, must be "İ", not "I"

Secondly, giving Turkish specific words exception raised.

Following use valid after this commit:

Avatarly.generate_avatar("ş", lang: :tr)

