### PR TITLE
Fixed an error when the text has a non-word character and a space next to it

### DIFF
--- a/lib/avatarly.rb
+++ b/lib/avatarly.rb
@@ -17,9 +17,9 @@ class Avatarly
   class << self
     def generate_avatar(text, opts={})
       if opts[:lang]
-        text = UnicodeUtils.upcase(initials(text.to_s.strip.gsub(/[^[[:word:]] ]/,'')), opts[:lang])
+        text = UnicodeUtils.upcase(initials(text.to_s.gsub(/[^[[:word:]] ]/,'').strip), opts[:lang])
       else
-        text = initials(text.to_s.strip.gsub(/[^\w ]/,'')).upcase
+        text = initials(text.to_s.gsub(/[^\w ]/,'').strip).upcase
       end
       generate_image(text, parse_options(opts)).to_blob
     end
@@ -68,8 +68,7 @@ class Avatarly
 
     def initials_for_separator(text, separator)
       if text.include?(separator)
-        text = text.split(separator)
-        text[0][0] + text[1][0]
+        text.split(separator).compact.map{|part| part[0]}.join
       else
         text[0] || ''
       end

--- a/spec/avatarly_spec.rb
+++ b/spec/avatarly_spec.rb
@@ -57,6 +57,18 @@ describe Avatarly do
         assert_image_equality(result, :H_black_white_32)
       end
 
+      it 'does not break if input has a space and non-word character' do
+        result = described_class.generate_avatar("H !",
+                                                 background_color: "#000000")
+        assert_image_equality(result, :H_black_white_32)
+      end
+
+      it 'does not break if input has a dot and non-word character' do
+        result = described_class.generate_avatar("H.!",
+                                                 background_color: "#000000")
+        assert_image_equality(result, :H_black_white_32)
+      end
+
       it 'does not break if input has leading or trailing non-word character' do
         result = described_class.generate_avatar("%HelloWorld!",
                                                  background_color: "#000000")
@@ -66,7 +78,7 @@ describe Avatarly do
       it 'does not break if no text found' do
         result = described_class.generate_avatar(nil,
                                                  background_color: "#000000")
-        assert_image_equality(result, :black_empty, 34)
+        assert_image_equality(result, :black_empty, 38)
       end
 
       it 'strips leading/trailing whitespace without striping other whitespaces' do


### PR DESCRIPTION
This PR fixes `undefined method '[]' for nil:NilClass` for texts like this one `Hello !`