### PR TITLE
Allow custom separator to be used in text

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 ---
 language: ruby
 rvm:
-  - 1.9.3
-  - 2.0.0
-  - 2.1.0
-  - 2.1.1
+  - 2.6
+  - 2.5
+  - 2.4
+  - 2.3
 before_install:
   - "echo 'gem: --no-ri --no-rdoc' > ~/.gemrc"
   - gem install bundler

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ the only required parameter is <tt>text</tt>. Other options that you can pass ar
 * <tt>vertical_offset</tt> (default: 0)
 * <tt>format</tt> (default: png)
 * <tt>lang</tt> (language code if unicode aware upcase required - e.g: :tr, default: nil)
+* <tt>separator</tt> (the custom string or regex used to split <tt>text</tt> into its initials)
 
 As a result you will get an image blob - rest is up to you, do whatever you want with it.
 

--- a/lib/avatarly.rb
+++ b/lib/avatarly.rb
@@ -17,9 +17,9 @@ class Avatarly
   class << self
     def generate_avatar(text, opts={})
       if opts[:lang]
-        text = UnicodeUtils.upcase(initials(text.to_s.gsub(/[^[[:word:]] ]/,'').strip), opts[:lang])
+        text = UnicodeUtils.upcase(initials(text.to_s.gsub(/[^[[:word:]] ]/,'').strip, opts), opts[:lang])
       else
-        text = initials(text.to_s.gsub(/[^\w ]/,'').strip).upcase
+        text = initials(text.to_s.gsub(/[^\w ]/,'').strip, opts).upcase
       end
       generate_image(text, parse_options(opts)).to_blob
     end
@@ -56,8 +56,10 @@ class Avatarly
       end.annotate(canvas, 0, 0, 0, opts[:vertical_offset], text)
     end
 
-    def initials(text)
-      if text.is_email?
+    def initials(text, opts)
+      if opts[:separator]
+        initials_for_separator(text, opts[:separator])
+      elsif text.is_email?
         initials_for_separator(text.split("@").first, ".")
       elsif text.include?(" ")
         initials_for_separator(text, " ")

--- a/spec/avatarly_spec.rb
+++ b/spec/avatarly_spec.rb
@@ -51,6 +51,13 @@ describe Avatarly do
         assert_image_equality(result, :H_black_white_32)
       end
 
+      it 'can generate using custom separators' do
+        result = described_class.generate_avatar("hfoow",
+                                                 background_color: "#000000",
+                                                 separator: "foo")
+        assert_image_equality(result, :HW_black_white_32, 34)
+      end
+
       it 'does not break if input has leading or trailing space' do
         result = described_class.generate_avatar(" HelloWorld ",
                                                  background_color: "#000000")
@@ -82,7 +89,7 @@ describe Avatarly do
       end
 
       it 'strips leading/trailing whitespace without striping other whitespaces' do
-        expect(described_class).to receive(:initials).with('Hello World').and_return 'HW'
+        expect(described_class).to receive(:initials).with('Hello World', {}).and_return 'HW'
         described_class.generate_avatar(' Hello World! ')
       end
     end


### PR DESCRIPTION
Adds a option `separator` which allows custom separators that can be set by the user.