### PR TITLE
Support for RMagick 4.1+

### DIFF
--- a/lib/avatarly.rb
+++ b/lib/avatarly.rb
@@ -48,11 +48,11 @@ class Avatarly
     end
 
     def draw_text(canvas, text, opts)
-      Magick::Draw.new do
-        self.pointsize = opts[:font_size]
-        self.font = opts[:font]
-        self.fill = opts[:font_color]
-        self.gravity = Magick::CenterGravity
+      Magick::Draw.new do |md|
+        md.pointsize = opts[:font_size]
+        md.font = opts[:font]
+        md.fill = opts[:font_color]
+        md.gravity = Magick::CenterGravity
       end.annotate(canvas, 0, 0, 0, opts[:vertical_offset], text)
     end
 


### PR DESCRIPTION
Recently I started receiving these deprecation messages:

```
gems/avatarly-1.6.0/lib/avatarly.rb:51: warning: passing a block without an image argument is deprecated
```

Seems like `self.` should not be used from within a block. This patch solved the issue for me.