### PR TITLE
Remove rfc822 gem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 *.gem
 .DS_Store
 Gemfile.lock
+.idea
+.cursor

--- a/Gemfile
+++ b/Gemfile
@@ -1,12 +1,12 @@
-source "http://rubygems.org"
+source 'http://rubygems.org'
 
 gemspec
 
 gem 'unicode_utils'
 
 group :development, :test do
-  gem 'rspec'
   gem 'fastimage'
-  gem 'phashion'
+  gem 'mini_magick'
   gem 'pry'
+  gem 'rspec'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gem 'unicode_utils'
 
 group :development, :test do
   gem 'fastimage'
-  gem 'mini_magick'
+  gem 'mini_magick', '~> 4.0'
   gem 'pry'
   gem 'rspec'
 end

--- a/avatarly.gemspec
+++ b/avatarly.gemspec
@@ -1,5 +1,5 @@
 Gem::Specification.new do |s|
-  s.add_runtime_dependency('rmagick')
+  s.add_runtime_dependency('mini_magick')
   s.add_runtime_dependency('rfc822')
   s.add_runtime_dependency('unicode_utils')
 

--- a/lib/avatarly.rb
+++ b/lib/avatarly.rb
@@ -1,31 +1,30 @@
-require 'rvg/rvg'
 require 'rfc822'
 require 'pathname'
 require 'unicode_utils'
 
 class Avatarly
   BACKGROUND_COLORS = [
-      "#ff4040", "#7f2020", "#cc5c33", "#734939", "#bf9c8f", "#995200",
-      "#4c2900", "#f2a200", "#ffd580", "#332b1a", "#4c3d00", "#ffee00",
-      "#b0b386", "#64664d", "#6c8020", "#c3d96c", "#143300", "#19bf00",
-      "#53a669", "#bfffd9", "#40ffbf", "#1a332e", "#00b3a7", "#165955",
-      "#00b8e6", "#69818c", "#005ce6", "#6086bf", "#000e66", "#202440",
-      "#393973", "#4700b3", "#2b0d33", "#aa86b3", "#ee00ff", "#bf60b9",
-      "#4d3949", "#ff00aa", "#7f0044", "#f20061", "#330007", "#d96c7b"
-    ].freeze
+    '#ff4040', '#7f2020', '#cc5c33', '#734939', '#bf9c8f', '#995200',
+    '#4c2900', '#f2a200', '#ffd580', '#332b1a', '#4c3d00', '#ffee00',
+    '#b0b386', '#64664d', '#6c8020', '#c3d96c', '#143300', '#19bf00',
+    '#53a669', '#bfffd9', '#40ffbf', '#1a332e', '#00b3a7', '#165955',
+    '#00b8e6', '#69818c', '#005ce6', '#6086bf', '#000e66', '#202440',
+    '#393973', '#4700b3', '#2b0d33', '#aa86b3', '#ee00ff', '#bf60b9',
+    '#4d3949', '#ff00aa', '#7f0044', '#f20061', '#330007', '#d96c7b'
+  ].freeze
 
   class << self
-    def generate_avatar(text, opts={})
-      if opts[:lang]
-        text = UnicodeUtils.upcase(initials(text.to_s.gsub(/[^[[:word:]] ]/,'').strip, opts), opts[:lang])
-      else
-        text = initials(text.to_s.gsub(/[^\w ]/,'').strip, opts).upcase
-      end
+    def generate_avatar(text, opts = {})
+      text = if opts[:lang]
+               UnicodeUtils.upcase(initials(text.to_s.gsub(/[^[[:word:]] ]/, '').strip, opts), opts[:lang])
+             else
+               initials(text.to_s.gsub(/[^\w ]/, '').strip, opts).upcase
+             end
       generate_image(text, parse_options(opts)).to_blob
     end
 
     def root
-      File.expand_path '../..', __FILE__
+      File.expand_path '..', __dir__
     end
 
     def lib
@@ -39,38 +38,35 @@ class Avatarly
     end
 
     def generate_image(text, opts)
-      image = Magick::RVG.new(opts[:size], opts[:size]).viewbox(0, 0, opts[:size], opts[:size]) do |canvas|
-        canvas.background_fill = opts[:background_color]
-      end.draw
-      image.format = opts[:format]
-      draw_text(image, text, opts) if text.length > 0
-      image
-    end
-
-    def draw_text(canvas, text, opts)
-      Magick::Draw.new do |md|
-        md.pointsize = opts[:font_size]
-        md.font = opts[:font]
-        md.fill = opts[:font_color]
-        md.gravity = Magick::CenterGravity
-      end.annotate(canvas, 0, 0, 0, opts[:vertical_offset], text)
+      command = MiniMagick::Tool::Convert.new
+      command.size "#{opts[:size]}x#{opts[:size]}"
+      if text.length.positive?
+        command.font opts[:font]
+        command.fill opts[:font_color]
+        command.gravity 'center'
+        command.pointsize opts[:font_size]
+        command.annotate  "+0+#{opts[:vertical_offset]}", text
+      end
+      command << "xc:#{opts[:background_color]}"
+      command << "#{opts[:format]}:-"
+      MiniMagick::Image.read(command.call)
     end
 
     def initials(text, opts)
       if opts[:separator]
         initials_for_separator(text, opts[:separator])
       elsif text.is_email?
-        initials_for_separator(text.split("@").first, ".")
-      elsif text.include?(" ")
-        initials_for_separator(text, " ")
+        initials_for_separator(text.split('@').first, '.')
+      elsif text.include?(' ')
+        initials_for_separator(text, ' ')
       else
-        initials_for_separator(text, ".")
+        initials_for_separator(text, '.')
       end
     end
 
     def initials_for_separator(text, separator)
       if text.include?(separator)
-        text.split(separator).compact.map{|part| part[0]}.join
+        text.split(separator).compact.map { |part| part[0] }.join
       else
         text[0] || ''
       end
@@ -82,7 +78,7 @@ class Avatarly
         size: 32,
         vertical_offset: 0,
         font: "#{fonts}/Roboto.ttf",
-        format: "png" }
+        format: 'png' }
     end
 
     def parse_options(opts)

--- a/lib/avatarly.rb
+++ b/lib/avatarly.rb
@@ -1,5 +1,5 @@
-require 'rfc822'
 require 'pathname'
+require 'uri'
 require 'unicode_utils'
 
 class Avatarly
@@ -39,6 +39,7 @@ class Avatarly
 
     def generate_image(text, opts)
       command = MiniMagick::Tool::Convert.new
+      command << "xc:#{opts[:background_color]}"
       command.size "#{opts[:size]}x#{opts[:size]}"
       if text.length.positive?
         command.font opts[:font]
@@ -47,7 +48,6 @@ class Avatarly
         command.pointsize opts[:font_size]
         command.annotate  "+0+#{opts[:vertical_offset]}", text
       end
-      command << "xc:#{opts[:background_color]}"
       command << "#{opts[:format]}:-"
       MiniMagick::Image.read(command.call)
     end
@@ -55,7 +55,7 @@ class Avatarly
     def initials(text, opts)
       if opts[:separator]
         initials_for_separator(text, opts[:separator])
-      elsif text.is_email?
+      elsif email?(text)
         initials_for_separator(text.split('@').first, '.')
       elsif text.include?(' ')
         initials_for_separator(text, ' ')
@@ -89,6 +89,12 @@ class Avatarly
       opts[:font_size] = opts[:font_size].to_i
       opts[:vertical_offset] = opts[:vertical_offset].to_i
       opts
+    end
+
+    def email?(string)
+      return false if string.nil?
+
+      string.match?(URI::MailTo::EMAIL_REGEXP)
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,7 @@
 require 'rspec'
 require 'avatarly'
-require 'phashion'
+require 'mini_magick'
+require 'securerandom'
 require 'support/avatar_expectations'
 require 'fastimage'
 require 'tempfile'


### PR DESCRIPTION
[the gem](https://github.com/dim/rfc-822) was archived in 2024

and the gem should be removed because it prevents of updating Ruby to version 3.3.* with old RegExp dependency

```
Fast Debugger (ruby-debug-ide 3.0.11, debase 3.0.11, file filtering is supported, block breakpoints supported, smart steps supported, obtaining return values supported, partial obtaining of instance variables supported) listens on 127.0.0.1:55424
/Users/roman/.rvm/gems/ruby-3.3.10/gems/bundler-2.7.2/lib/bundler/runtime.rb:75:in `rescue in block (2 levels) in require': There was an error while trying to load the gem 'avatarly'. (Bundler::GemRequireError)
Gem Load Error is: wrong number of arguments (given 3, expected 1..2)
```

the breaking change:
<img width="1346" height="499" alt="image" src="https://github.com/user-attachments/assets/749b91f4-781f-4b4a-b77a-f2e7c74613b5" />

the issue:
<img width="1268" height="296" alt="image" src="https://github.com/user-attachments/assets/25475a0a-9dca-4cf6-ba71-e5e55b55e07d" />
